### PR TITLE
Fix SyntaxWarning

### DIFF
--- a/pyatome/client.py
+++ b/pyatome/client.py
@@ -127,7 +127,7 @@ class AtomeClient(object):
             logging.info("Got 403, relogging (max retries: %s)",str(max_retries))
             return self._get_live(max_retries+1)
 
-        if req.text is "":
+        if req.text == "":
             raise PyAtomeError("No data")
 
         try:
@@ -170,7 +170,7 @@ class AtomeClient(object):
             logging.info("Got 403, relogging (max retries: %s)",str(max_retries))
             return self._get_consumption(max_retries+1)
 
-        if req.text is "":
+        if req.text == "":
             raise PyAtomeError("No data")
 
         try:


### PR DESCRIPTION
```bash
/nix/store/daxpq6axkp078ha9wx5r2z6lj4h1dan0-python3.9-pyatome-0.1.1/lib/python3.9/site-packages/pyatome/client.py:130: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if req.text is "":
/nix/store/daxpq6axkp078ha9wx5r2z6lj4h1dan0-python3.9-pyatome-0.1.1/lib/python3.9/site-packages/pyatome/client.py:173: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if req.text is "":
```